### PR TITLE
Fix FREERTOS_METAL_VENV_PATH default value setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 
-FREERTOS_METAL_VENV_PATH ?= venv
 
 override CURRENT_DIR := $(patsubst %/,%, $(dir $(abspath $(firstword $(MAKEFILE_LIST)))))
+
+ifeq ($(FREERTOS_METAL_VENV_PATH),)
+	override FREERTOS_METAL_VENV_PATH := $(CURRENT_DIR)/venv
+endif
 
 override SOURCE_DIR := $(CURRENT_DIR)/FreeRTOS-Kernel
 BUILD_DIR ?= $(CURRENT_DIR)/build


### PR DESCRIPTION
Set default FREERTOS_METAL_VENV_PATH value. 
In case FREERTOS_METAL_VENV_PATH is set but empty, an error on venv creation appear. This might happens for standalone project.