### PR TITLE
Fix external interrupt branch condition

### DIFF
--- a/FreeRTOS-Kernel/portable/GCC/RISC-V/portASM.S
+++ b/FreeRTOS-Kernel/portable/GCC/RISC-V/portASM.S
@@ -619,7 +619,7 @@ test_if_external_interrupt:			/* If there is a CLINT and the mtimer interrupt is
 	addi t1, t1, 4					/* 0x80000007 + 4 = 0x8000000b == Machine external interrupt. */
     csrr t2, mcause
 	bne t2, t1, unrecoverable_error	/* Something as yet unhandled. */
-	j unrecoverable_error
+	j external_interrupt
 
 #endif /* portasmHAS_CLINT */
 


### PR DESCRIPTION
Signed-off-by: Daniel Lee <daniel2.lee@semifive.com>

**Current issue**
When executing an external interrupt (PLIC), it always branches to'unrecoverable_error'.
So, after checking the conditions for t2, t1, need to modify from unrecoverable_error to external_interrupt.

**Test condition**
- The actual external interrupt behavior was confirmed by a customer using the S54 customized core, which connected the I2C interrupt to PLIC.
- OR, You can be created a similar condition via the E24 + SW interrupt + FreeRTOS example. In this case, when the operating code goes into test_if external interrupt, you need to manually modify the 'mcause' register as if the external interrupt occurred.

