### PR TITLE
Fix multiple overflow vulnerabilities

### DIFF
--- a/FreeRTOS-Kernel/portable/MemMang/heap_2.c
+++ b/FreeRTOS-Kernel/portable/MemMang/heap_2.c
@@ -131,21 +131,31 @@ void *pvReturn = NULL;
 			xHeapHasBeenInitialised = pdTRUE;
 		}
 
-		/* The wanted size is increased so it can contain a BlockLink_t
+		/* The wanted size must be increased so it can contain a BlockLink_t
 		structure in addition to the requested amount of bytes. */
-		if( xWantedSize > 0 )
+		if( ( xWantedSize > 0 ) && 
+            	    ( ( xWantedSize + heapSTRUCT_SIZE ) >  xWantedSize ) ) /* Overflow check */
 		{
 			xWantedSize += heapSTRUCT_SIZE;
 
-			/* Ensure that blocks are always aligned to the required number of bytes. */
-			if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0 )
+			/* Byte alignment required. Check for overflow. */
+            		if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) 
+                    		> xWantedSize )
 			{
-				/* Byte alignment required. */
 				xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+				configASSERT( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) == 0 );
+            		}
+			else
+			{
+				xWantedSize = 0;
 			}
+        	}
+        	else 
+        	{
+            		xWantedSize = 0;
 		}
-
-		if( ( xWantedSize > 0 ) && ( xWantedSize < configADJUSTED_HEAP_SIZE ) )
+		
+		if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )
 		{
 			/* Blocks are stored in byte order - traverse the list from the start
 			(smallest) block until one of adequate size is found. */

--- a/FreeRTOS-Kernel/portable/MemMang/heap_4.c
+++ b/FreeRTOS-Kernel/portable/MemMang/heap_4.c
@@ -136,28 +136,36 @@ void *pvReturn = NULL;
 		kernel, so it must be free. */
 		if( ( xWantedSize & xBlockAllocatedBit ) == 0 )
 		{
-			/* The wanted size is increased so it can contain a BlockLink_t
+			/* The wanted size must be increased so it can contain a BlockLink_t
 			structure in addition to the requested amount of bytes. */
-			if( xWantedSize > 0 )
+			if( ( xWantedSize > 0 ) && 
+			    ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) ) /* Overflow check */
 			{
 				xWantedSize += xHeapStructSize;
 
-				/* Ensure that blocks are always aligned to the required number
-				of bytes. */
+				/* Ensure that blocks are always aligned. */
 				if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
 				{
-					/* Byte alignment required. */
-					xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
-					configASSERT( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) == 0 );
+					/* Byte alignment required. Check for overflow. */
+					if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) 
+							> xWantedSize )
+					{
+						xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+						configASSERT( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) == 0 );
+					}
+					else
+					{
+						xWantedSize = 0;
+					}  
 				}
 				else
 				{
 					mtCOVERAGE_TEST_MARKER();
 				}
-			}
-			else
+			} 
+			else 
 			{
-				mtCOVERAGE_TEST_MARKER();
+				xWantedSize = 0;
 			}
 
 			if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )

--- a/FreeRTOS-Kernel/portable/MemMang/heap_5.c
+++ b/FreeRTOS-Kernel/portable/MemMang/heap_5.c
@@ -150,16 +150,24 @@ void *pvReturn = NULL;
 		{
 			/* The wanted size is increased so it can contain a BlockLink_t
 			structure in addition to the requested amount of bytes. */
-			if( xWantedSize > 0 )
+			if( ( xWantedSize > 0 ) && 
+			    ( ( xWantedSize + xHeapStructSize ) >  xWantedSize ) ) /* Overflow check */
 			{
 				xWantedSize += xHeapStructSize;
 
-				/* Ensure that blocks are always aligned to the required number
-				of bytes. */
+				/* Ensure that blocks are always aligned */
 				if( ( xWantedSize & portBYTE_ALIGNMENT_MASK ) != 0x00 )
 				{
-					/* Byte alignment required. */
-					xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+					/* Byte alignment required. Check for overflow */
+					if( ( xWantedSize + ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) ) ) >
+						xWantedSize )
+					{
+						xWantedSize += ( portBYTE_ALIGNMENT - ( xWantedSize & portBYTE_ALIGNMENT_MASK ) );
+					} 
+					else 
+					{
+						xWantedSize = 0;
+					}
 				}
 				else
 				{
@@ -168,7 +176,7 @@ void *pvReturn = NULL;
 			}
 			else
 			{
-				mtCOVERAGE_TEST_MARKER();
+				xWantedSize = 0;
 			}
 
 			if( ( xWantedSize > 0 ) && ( xWantedSize <= xFreeBytesRemaining ) )

--- a/FreeRTOS-Kernel/queue.c
+++ b/FreeRTOS-Kernel/queue.c
@@ -383,6 +383,9 @@ Queue_t * const pxQueue = xQueue;
 			/* Allocate enough space to hold the maximum number of items that
 			can be in the queue at any time. */
 			xQueueSizeInBytes = ( size_t ) ( uxQueueLength * uxItemSize ); /*lint !e961 MISRA exception as the casts are only redundant for some ports. */
+
+			/* Check for addition overflow. */
+			configASSERT( ( sizeof( Queue_t ) + xQueueSizeInBytes ) > xQueueSizeInBytes );
 		}
 
 		/* Allocate the queue and storage area.  Justification for MISRA


### PR DESCRIPTION
These commits backport the commit https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/47338393f1f79558f6144213409f09f81d7c4837 and https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/c7a9a01c94987082b223d3e59969ede64363da63 from the upstream FreeRTOS-Kernel which fix the following overflow vulnerabilities:
[CVE-2021-31571](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31571)
[CVE-2021-31572](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-31572)
[CVE-2021-32020](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-32020)

