### PR TITLE
Restore t0 before context saving in ecall_yield/handle_interrupt

### DIFF
--- a/FreeRTOS-Kernel/portable/GCC/RISC-V/portASM.S
+++ b/FreeRTOS-Kernel/portable/GCC/RISC-V/portASM.S
@@ -514,7 +514,7 @@ ecall_end:
 
 ecall_yield:
 	/* restore t0 */
-	csrr t0, mstatus
+	csrr t0, mscratch
 	portSAVE_BaseReg
 	/* a4 = mepc
 	 * a5 = mstatus
@@ -546,6 +546,7 @@ ecall_yield:
 	j	switch_context
 
 handle_interrupt:
+	csrr t0, mscratch
 	portSAVE_BaseReg
 	/* a4 = mepc
 	 * a5 = mstatus


### PR DESCRIPTION
t0 should be restored from mscratch not mstatus in ecall_yield. t0 restore is missing in handle_interrupt before context saving
